### PR TITLE
Add CI workflow for main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: NC Soccer Hudson CI Pipeline
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests
+        run: |
+          echo "Running tests..."
+          # Add your test commands here, for example:
+          # pytest -xvs
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    # Only run build on main branch pushes, not PRs
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build application
+        run: |
+          echo "Building application for main branch..."
+          # Add your build commands here
+
+  verify-deployment-readiness:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Verify deployment readiness
+        run: |
+          echo "Verifying deployment readiness..."
+          echo "To deploy to production, create and push a tag following the format v*.*.* after ensuring it exists in CHANGELOG.md"
+          echo "Example: git tag v0.2.0 && git push origin v0.2.0"

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -2,13 +2,31 @@
 
 ## Overview
 
-This document outlines the process for deploying the NC Soccer Hudson application using the tag-based deployment strategy.
+This document outlines the process for deploying the NC Soccer Hudson application using our CI/CD pipeline strategy.
+
+We have a two-stage pipeline:
+1. **CI Pipeline**: Runs on all merges to the `main` branch (not on feature branches)
+2. **Deployment Pipeline**: Only runs when a version tag is pushed
 
 The key benefits of this approach:
 
 1. **Controlled Deployments**: Deployments only occur when explicitly triggered by a new tag, not automatically on every push to `main`.
 2. **Versioned Releases**: Each deployment is tied to a specific version in the CHANGELOG.md.
 3. **Minimal Disruption**: The deployment process avoids rebuilding Docker containers unnecessarily, using SSH to pull new code and restart services.
+4. **Quality Control**: Tests run on all PRs and merges to main, but deployments are a separate manual step.
+
+## CI Pipeline
+
+The CI pipeline runs automatically in two scenarios:
+- When a pull request is opened against the `main` branch
+- When changes are merged to the `main` branch
+
+This pipeline:
+1. Runs tests to verify code quality
+2. Builds the application (only on merges to `main`, not on PRs)
+3. Verifies deployment readiness
+
+The CI pipeline does not deploy to production. To deploy to production, you must create and push a tag.
 
 ## Deployment Process
 


### PR DESCRIPTION
This PR adds a separate CI workflow that runs on main branch merges but not on feature branches. It also updates the deployment documentation to explain our two-stage CI/CD pipeline.