### PR TITLE
Fix CI workflow to use uv for dependency management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,14 @@ jobs:
           python-version: '3.10'
           cache: 'pip'
 
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          uv pip install -r requirements.in
 
       - name: Run tests
         run: |


### PR DESCRIPTION
## Summary
- Fixed CI workflow failure by switching from pip to uv for dependency management
- Added step to install uv using the official installer
- Modified dependency installation to use requirements.in instead of requirements.txt

## Test plan
- CI workflow should now successfully install dependencies using uv
- This should fix the failing test job in the pipeline

🤖 Generated with [Claude Code](https://claude.ai/code)