### PR TITLE
Fix uv install command in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,14 @@ jobs:
           python-version: '3.10'
           cache: 'pip'
 
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          uv pip install -r requirements.in
 
       - name: Run tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install -r requirements.in
+          uv pip install --system -r requirements.in
 
       - name: Run tests
         run: |


### PR DESCRIPTION
## Summary
- Fixed the uv pip install command by adding the `--system` flag
- This allows uv to install packages in a non-virtual environment on CI

## Test plan
- CI workflow should now successfully install dependencies with uv
- The test job should pass in the pipeline

🤖 Generated with [Claude Code](https://claude.ai/code)